### PR TITLE
Make yiic.php point at new yii/framework location

### DIFF
--- a/protected/yiic.php
+++ b/protected/yiic.php
@@ -1,7 +1,7 @@
 <?php
 
 // change the following paths if necessary
-$yiic=dirname(__FILE__).'/lib/yii-1.1.9.r3527/framework/yiic.php';
+$yiic=dirname(__FILE__).'/vendor/yii/framework/yiic.php';
 $config=dirname(__FILE__).'/config/console.php';
 
 require_once($yiic);


### PR DESCRIPTION
Update yiic.php with new location for yii.   Migrations fail without fix.
